### PR TITLE
feat: Add deep linking support with simulatedev:// protocol

### DIFF
--- a/DEEP_LINK_ROUTING.md
+++ b/DEEP_LINK_ROUTING.md
@@ -1,0 +1,167 @@
+# Deep Link Routing Guide
+
+This document explains how to add new URL routes with deep links in the SimulateDev macOS app.
+
+## Current Setup
+
+The app is configured to handle deep links with the `simulatedev://` protocol. Deep link handling is implemented primarily in React with minimal Rust code.
+
+### Existing Routes
+
+- `simulatedev://login` - Opens the app on the login screen
+- `simulatedev://home` - Opens the app on the home screen  
+- `simulatedev://task?id=<taskId>` - Opens the app on a specific task screen
+
+## Adding New Routes
+
+### 1. Update the Deep Link Handler
+
+Edit `/src/pages/Index.tsx` and add your new route to the switch statement in the `useEffect` hook:
+
+```typescript
+// Handle deep link navigation
+useEffect(() => {
+  if (deepLinkUrl) {
+    const parsed = parseDeepLink(deepLinkUrl);
+    if (parsed) {
+      switch (parsed.path) {
+        case '/login':
+          setCurrentScreen('login');
+          break;
+        case '/home':
+          setCurrentScreen('home');
+          break;
+        case '/task':
+          const taskId = parsed.params.id;
+          if (taskId) {
+            setSelectedTaskId(taskId);
+            setCurrentScreen('task');
+          } else {
+            setCurrentScreen('home');
+          }
+          break;
+        // ADD YOUR NEW ROUTE HERE
+        case '/your-new-route':
+          // Handle your route logic
+          // Access URL parameters via parsed.params
+          break;
+        default:
+          setCurrentScreen(currentScreen === 'login' ? 'login' : 'home');
+          break;
+      }
+    }
+    clearDeepLink();
+  }
+}, [deepLinkUrl, parseDeepLink, clearDeepLink, currentScreen]);
+```
+
+### 2. Add Screen State (if needed)
+
+If you're adding a completely new screen, update the `Screen` type:
+
+```typescript
+type Screen = 'login' | 'home' | 'task' | 'your-new-screen';
+```
+
+### 3. Add Routing Logic
+
+Add the corresponding JSX rendering logic for your new screen:
+
+```typescript
+{currentScreen === 'your-new-screen' && (
+  <YourNewScreen />
+)}
+```
+
+## Parsing URL Parameters
+
+The `parseDeepLink` function automatically parses URL parameters. For example:
+
+- `simulatedev://settings?tab=profile&theme=dark`
+- Parameters are accessible via `parsed.params.tab` and `parsed.params.theme`
+
+### Example: Adding a Settings Route
+
+1. **Add to switch statement:**
+```typescript
+case '/settings':
+  const tab = parsed.params.tab || 'general';
+  const theme = parsed.params.theme;
+  setCurrentScreen('settings');
+  setSettingsTab(tab);
+  if (theme) setTheme(theme);
+  break;
+```
+
+2. **Add screen type:**
+```typescript
+type Screen = 'login' | 'home' | 'task' | 'settings';
+```
+
+3. **Add rendering:**
+```typescript
+{currentScreen === 'settings' && (
+  <SettingsScreen initialTab={settingsTab} />
+)}
+```
+
+## Testing Deep Links
+
+1. **Build the app:** `npm run tauri build`
+2. **Install the built app**
+3. **Test in browser address bar:** `simulatedev://your-route?param=value`
+4. **Or use Terminal:** `open "simulatedev://your-route?param=value"`
+
+## Architecture Notes
+
+- **Rust code is minimal** - Only initializes the deep-link plugin
+- **React handles routing** - All URL parsing and navigation logic is in React
+- **No additional Rust changes needed** - The plugin registration in `src-tauri/src/lib.rs` handles all deep link events
+
+## File Locations
+
+- **React deep link hook:** `/src/hooks/useDeepLink.ts`
+- **Main routing logic:** `/src/pages/Index.tsx`
+- **Rust plugin setup:** `/src-tauri/src/lib.rs`
+- **Tauri config:** `/src-tauri/tauri.conf.json`
+
+## Common Patterns
+
+### Route with Required Parameter
+```typescript
+case '/profile':
+  const userId = parsed.params.userId;
+  if (!userId) {
+    // Handle missing required parameter
+    setCurrentScreen('home');
+    return;
+  }
+  setCurrentScreen('profile');
+  setSelectedUserId(userId);
+  break;
+```
+
+### Route with Optional Parameters
+```typescript
+case '/search':
+  const query = parsed.params.q || '';
+  const category = parsed.params.category || 'all';
+  setCurrentScreen('search');
+  setSearchQuery(query);
+  setSearchCategory(category);
+  break;
+```
+
+### Route with Complex State
+```typescript
+case '/workspace':
+  const workspaceId = parsed.params.id;
+  const view = parsed.params.view || 'overview';
+  const highlightTask = parsed.params.highlight;
+  
+  setCurrentScreen('workspace');
+  setSelectedWorkspaceId(workspaceId);
+  setWorkspaceView(view);
+  if (highlightTask) setHighlightedTaskId(highlightTask);
+  break;
+```

--- a/tauri-macos/package.json
+++ b/tauri-macos/package.json
@@ -60,7 +60,8 @@
     "vaul": "^0.9.3",
     "zod": "^3.23.8",
     "@tauri-apps/api": "^2",
-    "@tauri-apps/plugin-opener": "^2"
+    "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-deep-link": "^2"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/tauri-macos/pnpm-lock.yaml
+++ b/tauri-macos/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2
         version: 2.7.0
+      '@tauri-apps/plugin-deep-link':
+        specifier: ^2
+        version: 2.4.1
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.4.0
@@ -1404,6 +1407,9 @@ packages:
     resolution: {integrity: sha512-RcGWR4jOUEl92w3uvI0h61Llkfj9lwGD1iwvDRD2isMrDhOzjeeeVn9aGzeW1jubQ/kAbMYfydcA4BA0Cy733Q==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-deep-link@2.4.1':
+    resolution: {integrity: sha512-I8Bo+spcAKGhIIJ1qN/gapp/Ot3mosQL98znxr975Zn2ODAkUZ++BQ9FnTpR7PDwfIl5ANSGdIW/YU01zVTcJw==}
 
   '@tauri-apps/plugin-opener@2.4.0':
     resolution: {integrity: sha512-43VyN8JJtvKWJY72WI/KNZszTpDpzHULFxQs0CJBIYUdCRowQ6Q1feWTDb979N7nldqSuDOaBupZ6wz2nvuWwQ==}
@@ -3647,6 +3653,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.7.1
       '@tauri-apps/cli-win32-ia32-msvc': 2.7.1
       '@tauri-apps/cli-win32-x64-msvc': 2.7.1
+
+  '@tauri-apps/plugin-deep-link@2.4.1':
+    dependencies:
+      '@tauri-apps/api': 2.7.0
 
   '@tauri-apps/plugin-opener@2.4.0':
     dependencies:

--- a/tauri-macos/src-tauri/Cargo.lock
+++ b/tauri-macos/src-tauri/Cargo.lock
@@ -506,6 +506,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +613,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -778,6 +804,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1393,6 +1428,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2373,6 +2414,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2964,6 +3015,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-ini"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7295b7ce3bf4806b419dc3420745998b447178b7005e2011947b38fc5aa6791"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3295,6 +3356,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-deep-link",
  "tauri-plugin-opener",
 ]
 
@@ -3676,6 +3738,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fec67f32d7a06d80bd3dc009fdb678c35a66116d9cb8cd2bb32e406c2b5bbd2"
+dependencies = [
+ "dunce",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.12",
+ "tracing",
+ "url",
+ "windows-registry",
+ "windows-result",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3888,6 +3970,15 @@ checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -4634,6 +4725,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core",
  "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]

--- a/tauri-macos/src-tauri/Cargo.toml
+++ b/tauri-macos/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
+tauri-plugin-deep-link = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/tauri-macos/src-tauri/src/lib.rs
+++ b/tauri-macos/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ fn greet(name: &str) -> String {
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_deep_link::init())
         .invoke_handler(tauri::generate_handler![greet])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/tauri-macos/src-tauri/tauri.conf.json
+++ b/tauri-macos/src-tauri/tauri.conf.json
@@ -32,5 +32,13 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ]
+  },
+  "plugins": {
+    "deep-link": {
+      "mobile": [],
+      "desktop": {
+        "schemes": ["simulatedev"]
+      }
+    }
   }
 }

--- a/tauri-macos/src/hooks/useDeepLink.ts
+++ b/tauri-macos/src/hooks/useDeepLink.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { onOpenUrl } from '@tauri-apps/plugin-deep-link';
+
+export function useDeepLink() {
+  const [deepLinkUrl, setDeepLinkUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Listen for deep link events
+    const unlisten = onOpenUrl((urls) => {
+      if (urls.length > 0) {
+        setDeepLinkUrl(urls[0]);
+      }
+    });
+
+    return () => {
+      unlisten.then(fn => fn());
+    };
+  }, []);
+
+  const parseDeepLink = (url: string) => {
+    try {
+      const parsedUrl = new URL(url);
+      const path = parsedUrl.pathname;
+      const searchParams = new URLSearchParams(parsedUrl.search);
+      
+      return {
+        path,
+        params: Object.fromEntries(searchParams.entries())
+      };
+    } catch (error) {
+      console.error('Failed to parse deep link URL:', error);
+      return null;
+    }
+  };
+
+  const clearDeepLink = () => {
+    setDeepLinkUrl(null);
+  };
+
+  return {
+    deepLinkUrl,
+    parseDeepLink,
+    clearDeepLink
+  };
+}

--- a/tauri-macos/src/pages/Index.tsx
+++ b/tauri-macos/src/pages/Index.tsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { LoginScreen } from "../components/LoginScreen";
 import { Sidebar } from "../components/Sidebar";
 import { HomeScreen } from "../components/HomeScreen";
 import { TaskScreen } from "../components/TaskScreen";
 import { CommandPalette } from "../components/CommandPalette";
 import { NavigationHeader } from "../components/NavigationHeader";
+import { useDeepLink } from "../hooks/useDeepLink";
 
 type Screen = 'login' | 'home' | 'task';
 
@@ -12,6 +13,7 @@ const Index = () => {
   const [currentScreen, setCurrentScreen] = useState<Screen>('login');
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [isCommandPaletteOpen, setIsCommandPaletteOpen] = useState(false);
+  const { deepLinkUrl, parseDeepLink, clearDeepLink } = useDeepLink();
 
   const handleLogin = () => {
     setCurrentScreen('home');
@@ -42,6 +44,37 @@ const Index = () => {
   const handleCommandK = () => {
     setIsCommandPaletteOpen(true);
   };
+
+  // Handle deep link navigation
+  useEffect(() => {
+    if (deepLinkUrl) {
+      const parsed = parseDeepLink(deepLinkUrl);
+      if (parsed) {
+        switch (parsed.path) {
+          case '/login':
+            setCurrentScreen('login');
+            break;
+          case '/home':
+            setCurrentScreen('home');
+            break;
+          case '/task':
+            const taskId = parsed.params.id;
+            if (taskId) {
+              setSelectedTaskId(taskId);
+              setCurrentScreen('task');
+            } else {
+              setCurrentScreen('home');
+            }
+            break;
+          default:
+            // Unknown path, default to home if logged in, login otherwise
+            setCurrentScreen(currentScreen === 'login' ? 'login' : 'home');
+            break;
+        }
+      }
+      clearDeepLink();
+    }
+  }, [deepLinkUrl, parseDeepLink, clearDeepLink, currentScreen]);
 
   // Get current task name for navigation
   const getCurrentTaskName = () => {


### PR DESCRIPTION
- Configure Tauri deep-link plugin for simulatedev:// protocol
- Add React hook for deep link URL parsing and handling
- Implement navigation routing for /login, /home, and /task paths
- Support URL parameters for task-specific deep links
- Minimal Rust code - all routing logic handled in React
- Add comprehensive documentation for extending deep link routes

🤖 Generated with [Claude Code](https://claude.ai/code)