### PR TITLE
feat: Add health check with startup and connection failed screens

### DIFF
--- a/tauri-macos/src/components/ConnectionFailedScreen.tsx
+++ b/tauri-macos/src/components/ConnectionFailedScreen.tsx
@@ -1,0 +1,44 @@
+import { Rocket, RefreshCw } from "lucide-react";
+import { Button } from "./ui/button";
+
+interface ConnectionFailedScreenProps {
+  onRetry: () => void;
+}
+
+export function ConnectionFailedScreen({ onRetry }: ConnectionFailedScreenProps) {
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center">
+      <div className="text-center max-w-md">
+        {/* Logo */}
+        <div className="space-y-2 mb-8">
+          <h1 className="text-4xl font-mono font-semibold text-foreground tracking-tight flex items-center justify-center gap-3">
+            <Rocket className="w-10 h-10" />
+            SimulateDev
+          </h1>
+        </div>
+
+        {/* Connection failed message */}
+        <div className="mb-6">
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            Connection Failed
+          </h2>
+          <p className="text-gray-600 text-sm mb-4">
+            Unable to connect to the SimulateDev server.
+          </p>
+          <p className="text-gray-500 text-xs">
+            Make sure the server is running at localhost:8000
+          </p>
+        </div>
+
+        {/* Retry button */}
+        <Button
+          onClick={onRetry}
+          className="bg-foreground text-background hover:bg-gray-800 px-8 py-3 rounded-lg font-medium flex items-center gap-2 mx-auto transition-colors"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Retry Connection
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/tauri-macos/src/components/StartupScreen.tsx
+++ b/tauri-macos/src/components/StartupScreen.tsx
@@ -1,0 +1,31 @@
+import { Rocket } from "lucide-react";
+
+interface StartupScreenProps {
+  message?: string;
+}
+
+export function StartupScreen({ message = "STARTING UP..." }: StartupScreenProps) {
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center">
+      <div className="text-center">
+        {/* Logo */}
+        <div className="space-y-2 mb-8">
+          <h1 className="text-4xl font-mono font-semibold text-foreground tracking-tight flex items-center justify-center gap-3">
+            <Rocket className="w-10 h-10" />
+            SimulateDev
+          </h1>
+        </div>
+
+        {/* Loading indicator */}
+        <div className="mb-4">
+          <div className="w-8 h-8 border-2 border-foreground border-t-transparent rounded-full animate-spin mx-auto"></div>
+        </div>
+
+        {/* Status message */}
+        <p className="text-foreground text-lg font-mono">
+          {message}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/tauri-macos/src/services/healthCheck.ts
+++ b/tauri-macos/src/services/healthCheck.ts
@@ -1,0 +1,81 @@
+const API_BASE_URL = 'http://localhost:8000';
+const HEALTH_CHECK_INTERVAL = 30000; // 30 seconds
+const MAX_CONSECUTIVE_FAILURES = 3;
+
+export interface HealthCheckResult {
+  isHealthy: boolean;
+  error?: string;
+  consecutiveFailures?: number;
+}
+
+export class HealthCheckService {
+  private intervalId: NodeJS.Timeout | null = null;
+  private isRunning = false;
+  private consecutiveFailures = 0;
+
+  async checkHealth(): Promise<HealthCheckResult> {
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/health`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        timeout: 5000, // 5 second timeout
+      });
+
+      if (response.ok) {
+        this.consecutiveFailures = 0;
+        return { isHealthy: true, consecutiveFailures: 0 };
+      } else {
+        this.consecutiveFailures++;
+        return { 
+          isHealthy: false, 
+          error: `Server returned ${response.status}`,
+          consecutiveFailures: this.consecutiveFailures
+        };
+      }
+    } catch (error) {
+      this.consecutiveFailures++;
+      return { 
+        isHealthy: false, 
+        error: error instanceof Error ? error.message : 'Unknown error',
+        consecutiveFailures: this.consecutiveFailures
+      };
+    }
+  }
+
+  startPeriodicHealthChecks(onHealthChange: (result: HealthCheckResult) => void): void {
+    if (this.isRunning) {
+      return;
+    }
+
+    this.isRunning = true;
+    
+    // Check immediately
+    this.checkHealth().then(onHealthChange);
+    
+    // Set up periodic checks
+    this.intervalId = setInterval(async () => {
+      const result = await this.checkHealth();
+      onHealthChange(result);
+    }, HEALTH_CHECK_INTERVAL);
+  }
+
+  stopPeriodicHealthChecks(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+    this.isRunning = false;
+  }
+
+  resetFailureCount(): void {
+    this.consecutiveFailures = 0;
+  }
+
+  getConsecutiveFailures(): number {
+    return this.consecutiveFailures;
+  }
+}
+
+export const healthCheckService = new HealthCheckService();


### PR DESCRIPTION
- Add StartupScreen component with configurable message and loading spinner
- Add ConnectionFailedScreen with retry functionality and localhost:8000 note
- Implement HealthCheckService with periodic checks and failure tracking
- Add health check logic to app startup flow:
  - Shows "STARTING UP..." during initial connection
  - Shows connection failed screen after 3 consecutive startup failures
  - Shows "CONNECTION WITH SERVER LOST, REESTABLISHING..." when connection drops after startup
- Deep links only work when server is healthy
- Periodic health checks every 30 seconds with automatic reconnection

🤖 Generated with [Claude Code](https://claude.ai/code)